### PR TITLE
adding check for GitHub token and changing info formatting

### DIFF
--- a/cli/info.go
+++ b/cli/info.go
@@ -1,15 +1,12 @@
 package cli
 
 import (
-	"fmt"
 	"log"
-	"strconv"
-	"strings"
 
 	"github.com/DataDrake/cli-ng/cmd"
 	"github.com/alecbcs/lookout/config"
 	"github.com/alecbcs/lookout/database"
-	"github.com/gookit/color"
+
 )
 
 // Info gets an entry from the database and displays the relevant information.
@@ -34,31 +31,6 @@ func InfoRun(r *cmd.RootCMD, c *cmd.CMD) {
 	result, err := database.Get(db, args.ID)
 	if err != nil {
 		log.Fatal("Unable to locate: " + args.ID)
-	}
-	red := color.FgRed.Render("%-20s: %s\n")
-	cyan := color.FgCyan.Render("%-20s: %s\n")
-	white := "%-20s: %s\n"
-
-	id := cyan
-	latestURL := white
-	latestVersion := white
-	currentURL := white
-	currentVersion := white
-
-	if !result.UpToDate {
-		id = red
-		latestURL = cyan
-		latestVersion = cyan
-		currentURL = red
-		currentVersion = red
-	}
-	fmt.Printf(id, "Package ID", result.ID)
-	fmt.Printf(latestURL, "LatestURL", result.LatestURL)
-	fmt.Printf(currentURL, "CurrentURL", result.CurrentURL)
-	fmt.Printf(latestVersion, "LatestVersion", strings.Join(result.LatestVersion, "."))
-	fmt.Printf(currentVersion, "CurrentVersion", strings.Join(result.CurrentVersion, "."))
-	fmt.Printf("%-20s: %s\n", "Up-To-Date", strconv.FormatBool(result.UpToDate))
-	if len(result.Dependencies) > 0 {
-		fmt.Printf("%-20s: %s\n", "Dependencies", strings.Join(result.Dependencies, ", "))
-	}
+	}       
+        result.PrintEntry()
 }

--- a/results/entries.go
+++ b/results/entries.go
@@ -1,7 +1,9 @@
 package results
 
 import (
+	"fmt"
 	"strings"
+	"strconv"
 
 	"github.com/DataDrake/cuppa/version"
 )
@@ -16,6 +18,20 @@ type Entry struct {
 	Dependencies   []string
 	UpToDate       bool
 }
+
+// printResult formats a result object correctly to print
+func (e Entry) PrintEntry() {
+	fmt.Printf("%-20s: %s\n", "Package ID", e.ID)
+	fmt.Printf("%-20s: %s\n", "Up-To-Date", strconv.FormatBool(e.UpToDate))
+	fmt.Printf("%-20s: %s\n", "LatestVersion", strings.Join(e.LatestVersion, "."))
+	fmt.Printf("%-20s: %s\n", "CurrentVersion", strings.Join(e.CurrentVersion, "."))
+	fmt.Printf("%-20s: %s\n", "Latest", e.LatestURL)
+	fmt.Printf("%-20s: %s\n", "Current", e.CurrentURL)
+	if len(e.Dependencies) > 0 {
+		fmt.Printf("%-20s: %s\n", "Dependencies", strings.Join(e.Dependencies, ", "))
+	}
+}
+
 
 // New creates a new Database Entry structure to store data in.
 func New(id string, latest string, latestv version.Version, current string, currentv version.Version, up2date bool) *Entry {

--- a/update/update.go
+++ b/update/update.go
@@ -11,11 +11,7 @@ import (
 
 func init() {
 	// Port Lookout configuration to CUPPA
-        cuppa.Global.Github.Key = config.Global.Github.Key
-
-	if config.Global.Github.Key == "" {
-		log.Fatal("A GitHub token is required in your $HOME/.config/lookout/lookout.config")
-	}
+	cuppa.Global.Github.Key = config.Global.Github.Key
 }
 
 // CheckUpdate checks a given URL for the latest available release.
@@ -30,9 +26,13 @@ func CheckUpdate(archive string) (*results.Result, bool) {
 			continue
 		}
 
+		// GitHub will never work without a token
+		if p.Name() == "GitHub" && cuppa.Global.Github.Key == "" {
+			log.Fatal("A GitHub token is required in your $HOME/.config/lookout/lookout.config")
+		}
+
 		// Pull the latest (non-beta) release from repository.
 		r, s := p.Latest(name)
-
 		if s != results.OK {
 			continue
 		}

--- a/update/update.go
+++ b/update/update.go
@@ -5,11 +5,17 @@ import (
 	"github.com/DataDrake/cuppa/providers"
 	"github.com/DataDrake/cuppa/results"
 	"github.com/alecbcs/lookout/config"
+
+	"log"
 )
 
 func init() {
 	// Port Lookout configuration to CUPPA
-	cuppa.Global.Github.Key = config.Global.Github.Key
+        cuppa.Global.Github.Key = config.Global.Github.Key
+
+	if config.Global.Github.Key == "" {
+		log.Fatal("A GitHub token is required in your $HOME/.config/lookout/lookout.config")
+	}
 }
 
 // CheckUpdate checks a given URL for the latest available release.
@@ -23,8 +29,10 @@ func CheckUpdate(archive string) (*results.Result, bool) {
 		if name == "" {
 			continue
 		}
+
 		// Pull the latest (non-beta) release from repository.
 		r, s := p.Latest(name)
+
 		if s != results.OK {
 			continue
 		}


### PR DESCRIPTION
This small PR will do the following:
 - add a check that the GitHub token is defined (the client will misleadingly return 404 if it's not, even when the repository exists)
 - restructure the formatting of the info command

This will close #2 - it doesn't do away with the need for GitHub auth, but does give a clear message that it doesn't work without it.

## GitHub Check
I'm not sure if the graphql API allows to not have a token, but looking over it briefly, it doesn't seem to (unlike the v3 which would allow some number of unauthenticated requests). As a sanity check I opened an issue to ask https://github.com/DataDrake/cuppa/issues/18. I do think it would be nice to be able to use the tool without needing to create the token - it's a small thing but probably would be a barrier for many users. It probably wouldn't be a big deal for an admin to do once and then forget about.

## Formatting
The current formatting is red and cyan, and not grouped. With this commit we change the color to white for readability and group the elements together logically. I first tested this out (I have a purple terminal) and my thinking is that color is a fairly powerful thing, and currently the colors don't add much to my ability to grab or quickly make sense of the information. So for the first part of this PR I want to propose that we have the output be more readable white.

I was first testing removing the url entirely, the idea being that for an "info" request the user really just cares about the versions! 

```bash
$ ./lookout info singularity
Package ID          : singularity
Latest              : 3.6.3
Current             : 3.6.2
Up-To-Date          : false
```

But thinking this through, the user wouldn't have any information about where to go to look for the package (e.g. GitHub) so I don't think this approach makes sense (at least as long as there isn't some other command or flag to "get more detail"). So next, I tried
reorganizing the information a bit:

```bash
Package ID          : singularity
Up-To-Date          : false
LatestVersion       : 3.6.3
CurrentVersion      : 3.6.2
Latest              : https://github.com/hpcng/singularity/archive/v3.6.3.tar.gz
Current             : https://github.com/hpcng/singularity/releases/download/v3.6.2/singularity-3.6.2.tar.gz
```
The reason for ordering above is the following. As a user, I'll start reading at the top, and I can quickly see if a package is up to date. If the second line is "true" then I am done, and will stop reading. If it's not, then I can quickly see the versions in the next two lines. Maybe after that I'd think "Oh, this doesn't look too hugely different, it's fine for now" and stop again. Only if I want to update the package would I possibly find use for the final two lines, the URLs. And they are also placed closest to the bottom to make a copy paste easy.

For the above, I also organized the print function into a method owned by the instance, since it mapped so nicely. If the result (Entry) is ever used elsewhere it will make it easy to quickly print.

Signed-off-by: vsoch <vsochat@stanford.edu>